### PR TITLE
Feature/fix dependencies

### DIFF
--- a/catalog_tools/analysis/estimate_beta.py
+++ b/catalog_tools/analysis/estimate_beta.py
@@ -1,7 +1,8 @@
 """This module contains functions for the estimation of beta and the b-value.
 """
+from typing import Optional, Tuple, Union
+
 import numpy as np
-from typing import Optional
 
 
 def estimate_beta_tinti(magnitudes: np.ndarray, mc: float, delta_m: float = 0,
@@ -70,7 +71,7 @@ def differences(magnitudes: np.ndarray) -> np.ndarray:
 
 
 def estimate_beta_elst(magnitudes: np.ndarray, delta_m: float = 0
-                       ) -> [float, float]:
+                       ) -> Union[float, Tuple[float, float]]:
     """ returns the b-value estimation using the positive differences of the
     Magnitudes
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,14 +8,14 @@ license = GNU AFFERO GENERAL PUBLIC LICENSE
 python_requires = >=3.8
 packages = find:
 install_requires =
-    matplotlib==3.7.1
-    numpy==1.24.2
-    pandas==1.5.3
-    shapely==2.0.1
-    obspy==1.4.0
-    geopandas==0.12.2
-    cartopy==0.21.1
-    notebook==6.5.3
+    matplotlib
+    numpy
+    pandas
+    shapely
+    obspy
+    geopandas
+    cartopy
+    notebook
 
 [options.packages.find]
 include=catalog_tools*
@@ -24,6 +24,7 @@ include=catalog_tools*
 dev =
     autopep8
     flake8
+    isort
     pytest
     pytest-cov
     tox


### PR DESCRIPTION
fixed the type hints for estimate elst

Also removed fixed versions from setup.cfg. I said this once already, the setup.cfg should not have fixed versions.

If there are errors with certain combinations of libraries, then either try to resolve them in the code (find out what is causing the error and resolve) or use for the libraries in question <= and >= version restrictions. but if somehow possible, never FIX a version, otherwise you will very often not be able to install this library along with other libraries.

If you want a reproducible environment for yourself and others where you are 100% sure it works, you can use a "requirements.txt". (pip freeze > requirements.txt)